### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/GPlay97/EVNotifyBackend.png?columns=all)](https://waffle.io/GPlay97/EVNotifyBackend?utm_source=badge)
 # EVNotifyBackend
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/GPlay97/EVNotifyBackend.svg)](https://greenkeeper.io/)


### PR DESCRIPTION
Merge this to receive a badge indicating columns and number of cards in your columns on your waffle.io board at https://waffle.io/GPlay97/EVNotifyBackend

This was requested by a real person (user GPlay97) on waffle.io, we're not trying to spam you.