### PR TITLE
rewrite createLogs to only use a single loop

### DIFF
--- a/v2/modules/cron/createLogs.js
+++ b/v2/modules/cron/createLogs.js
@@ -49,12 +49,10 @@ const createLogs = async () => {
             }
             var state = userStates[user];
             if (state.start && (row.charging != state.charging || row.timestamp > state.last + UNIQUE_DELAY)) {
-                console.log("end of entry", row);
                 inserts.push([user, state.start, state.last, state.charging, formatDate(state.start)]);
                 state = userStates[user] = { start: false, last: false, charging: false, driving: false, };
             }
             if (!state.start) {
-                console.log("new entry", row)
                 state.start = row.timestamp;
                 state.charging = row.charging;
             }

--- a/v2/modules/cron/createLogs.js
+++ b/v2/modules/cron/createLogs.js
@@ -49,7 +49,9 @@ const createLogs = async () => {
             }
             var state = userStates[user];
             if (state.start && (row.charging != state.charging || row.timestamp > state.last + UNIQUE_DELAY)) {
-                inserts.push([user, state.start, state.last, state.charging, formatDate(state.start)]);
+                if (state.driving || state.charging) {
+                    inserts.push([user, state.start, state.last, state.charging, formatDate(state.start)]);
+                }
                 state = userStates[user] = { start: false, last: false, charging: false, driving: false, };
             }
             if (!state.start) {

--- a/v2/modules/cron/createLogs.js
+++ b/v2/modules/cron/createLogs.js
@@ -31,56 +31,45 @@ const formatDate = (timestamp) => {
     return day + '.' + month + '.' + date.getFullYear() + ' ' + hours + ':' + minutes + ':' + seconds;
 };
 
+const UNIQUE_DELAY = 7200; // seconds for 2 hours
+
 /**
  * Creates logs for users
  */
 const createLogs = async () => {
     try {
-
-        let users = await query('SELECT akey FROM accounts');
-        users = users.map(user => user.akey);
-
-        for (const user of users) {
-            try {
-                let lastLog = ((await query('SELECT end FROM logs WHERE akey=? ORDER BY end DESC LIMIT 1', [user]))[0] || {}).end || 0;
-
-                /**
-                 * TODO:
-                 * - prevent to early logs (check timestamp ?!)
-                 */
-                let stats = await query('SELECT * FROM statistics WHERE akey=? AND timestamp > ? AND charging IS NOT NULL ORDER BY timestamp', [user, lastLog]);
-                let start;
-                let end;
-                let isDrive;
-
-                for (const [idX, stat] of stats.entries()) {
-                    let checked = false;
-                    for (const [nextIdX, nextStat] of stats.entries()) {
-                        if (!checked && nextIdX > idX) {
-                            checked = true;
-                            end = nextStat.timestamp;
-                            if (!isDrive && !parseInt(stat.charging) && stat.gps_speed != null) isDrive = true;
-                            let doubleChecked = false;
-                            let moreDataComing = false;
-                            for (const [doubleNextIdX, doubleNextStat] of stats.entries()) {
-                                if (!doubleChecked && doubleNextIdX > nextIdX) {
-                                    moreDataComing = doubleChecked = true;
-                                }
-                            }
-                            // check if next timestamp difference more than 4 hours - or charge type changed - and difference not more than one hour
-                            if (nextStat.timestamp - stat.timestamp < 3600 && (nextStat.timestamp >= stat.timestamp + 14400 || parseInt(nextStat.charging) !== parseInt(stat.charging) || !moreDataComing)) {
-                                if (parseInt(stat.charging) || isDrive) {
-                                    await query('INSERT INTO logs (akey, start, end, charge, title) VALUES (?, ?, ?, ?, ?)', [user, start, end, stat.charging, formatDate(start)]);
-                                    start = end = 0;
-                                }
-                            } else if (nextStat.timestamp - stat.timestamp > 3600) start = end;
-                        } else if (!start) start = nextStat.timestamp;
-                    }
-                }
-            } catch (err) {
-                console.error(err);
+        // TODO there could be a lot of results. Maybe streaming the results is a good idea?
+        let lastLogs = await query('SELECT akey,timestamp,charging,gps_speed FROM (SELECT akey, MAX(end) end FROM logs GROUP BY akey) l RIGHT JOIN (SELECT * FROM statistics WHERE charging IS NOT NULL ORDER BY timestamp) s USING (akey) WHERE s.timestamp>l.end OR l.end IS NULL');
+        var userStates = {};
+        var inserts = [];
+        for (const [idX, row] of lastLogs.entries()) {
+            var user = row.akey;
+            if (!userStates[user]) {
+                userStates[user] = { start: false, last: false, charging: false, driving: false, };
             }
+            var state = userStates[user];
+            if (state.start && (row.charging != state.charging || row.timestamp > state.last + UNIQUE_DELAY)) {
+                console.log("end of entry", row);
+                inserts.push([user, state.start, state.last, state.charging, formatDate(state.start)]);
+                state = userStates[user] = { start: false, last: false, charging: false, driving: false, };
+            }
+            if (!state.start) {
+                console.log("new entry", row)
+                state.start = row.timestamp;
+                state.charging = row.charging;
+            }
+            state.last = row.timestamp;
+            state.driving |= row.gps_speed && row.gps_speed > 1.389;
         }
+        Object.keys(userStates).forEach(key => {
+            if (!userStates.hasOwnProperty(key)) return;
+            var state = userStates[key];
+            if (state.last > new Date().getTime() / 1000 - UNIQUE_DELAY) return;
+            inserts.push([key, state.start, state.last, state.charging, formatDate(state.start)]);
+        });
+        // TODO batch insert instead of many singles, but current mysql library does not seem to support them
+        var insertPromises = inserts.map(insert => query('INSERT INTO logs (akey, start, end, charge, title) VALUES (?,?,?,?,?)', insert));
+        await Promise.all(insertPromises);
     } catch (err) {
         console.error(err);
     }


### PR DESCRIPTION
This pull request rewrites the code for creating the log table to use a single layer of loops instead of multiple nested ones. This should reduce the time complexity from O(n^3) to O(n).
This pull request should also fix #70 .

Because all inserts are now executed asynchronously, an entry with a higher starting time than another entry of the same user does not necessarily have a higher id.