### PR TITLE
[FIX] Remove npm from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "mysql": "2.17.0",
     "node-telegram-bot-api": "0.30.0",
     "nodemailer": "5.1.1",
-    "npm": "6.10.2",
     "password-hash": "1.2.2",
     "qrcode": "^1.3.2",
     "request": "2.88.0",


### PR DESCRIPTION
npm isn't used in the project, so it's not needed as a dependency in the `package.json`. There's a new version of npm installed on the server (@GPlay97 told me this), so it's not needed here :)   