### PR TITLE
refactor: Date now handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ if (srv_config.ROOKOUT_TOKEN) rookout.start({token: srv_config.ROOKOUT_TOKEN});
 
 // last activity track
 app.use((req, res, next) => {
-    if (req.body.akey) db.query('UPDATE accounts SET lastactivity=? WHERE akey=?', [parseInt(new Date() / 1000), req.body.akey], () => next());
+    if (req.body.akey) db.query('UPDATE accounts SET lastactivity=? WHERE akey=?', [Math.floor(Date.now() / 1000), req.body.akey], () => next());
     else next();
 });
 
@@ -155,7 +155,7 @@ app.post('/cat', cats.buyCat);
 app.post('/debug', (req, res) => {
     if (typeof req.body.data === 'string') {
         db.query('INSERT INTO debug (data, akey, timestamp) VALUES (?, ?, ?)', [
-            req.body.data, req.body.akey, ((parseInt(req.body.timestamp)) ? req.body.timestamp : parseInt(new Date() / 1000))
+            req.body.data, req.body.akey, ((parseInt(req.body.timestamp)) ? req.body.timestamp : Math.floor(Date.now() / 1000))
         ], (err, dbRes) => {
             if (!err && dbRes) {
                 res.json({status: true});

--- a/modules/integrations/abrp/index.js
+++ b/modules/integrations/abrp/index.js
@@ -80,7 +80,7 @@ const submitData = (akey) => {
         akey
     ], (err, dbRes) => {
         let data;
-        const now = parseInt(new Date() / 1000);
+        const now = Math.floor(Date.now() / 1000);
 
         if (!err && dbRes && (data = dbRes[0])) {
             const socUpToDate = now < data.last_soc + 300;
@@ -88,7 +88,7 @@ const submitData = (akey) => {
             
             if (data.abrp && cars[data.car] && (data.soc_display || data.soc_bms) && socUpToDate) {
                 const abrpData = {
-                    utc: new Date() / 1000,
+                    utc: now,
                     soc: data.soc_display || data.soc_bms,
                     speed: locationUpToDate ? data.gps_speed * 3.6 || 0 : 0,
                     lat: locationUpToDate ? data.latitude : 0,

--- a/modules/notification/index.js
+++ b/modules/notification/index.js
@@ -33,7 +33,7 @@ const send = (req, res) => {
         if (!err && dbRes && (userObj = dbRes[0]) != null) {
             // validate token
             if (userObj.token === req.body.token) {
-                const now = parseInt(new Date() / 1000);
+                const now = Math.floor(Date.now() / 1000);
 
                 // valid, compare last_notification timestamp to determine if limit reached
                 if ((userObj.last_notification || 0) + 60 < now) {

--- a/modules/qr/index.js
+++ b/modules/qr/index.js
@@ -232,7 +232,7 @@ module.exports = {
         qrStatus(req.query.code, (err, codeObj) => {
             if (!err && codeObj) {
                 // prevent access if not charging or data is to old (older than 10 minutes)
-                if (!codeObj.charging || (new Date() / 1000 - 600) > codeObj.last_soc) {
+                if (!codeObj.charging || (Date.now() / 1000 - 600) > codeObj.last_soc) {
                     res.status(401).json({
                         error: srv_errors.ACCESS_DENIED,
                         debug: ((srv_config.DEBUG) ? codeObj : null)
@@ -274,7 +274,7 @@ module.exports = {
             let dbObj;
 
             if (!err && dbRes && (dbObj = dbRes[0])) {
-                const now = parseInt(new Date() / 1000);
+                const now = Math.floor(Date.now() / 1000);
 
                 // valid, compare last_qr timestamp to determine if limit reached
                 if ((dbObj.last_qr || 0) + 600 < now) {

--- a/modules/sync/index.js
+++ b/modules/sync/index.js
@@ -16,7 +16,7 @@ const srv_config = require('./../../srv_config.json'),
  * @param {Function} callback callback function
  */
 const postSoC = (akey, socObj, callback) => {
-    const now = parseInt(new Date() / 1000);
+    const now = Math.floor(Date.now() / 1000);
 
     db.query('UPDATE sync SET soc_display=?, soc_bms=?, last_soc=? WHERE akey=?', [
         socObj.display, socObj.bms, now, akey
@@ -48,7 +48,7 @@ const getSoC = (akey, callback) => {
  * @param {Function} callback callback function
  */
 const postExtended = (akey, extendedObj, callback) => {
-    const now = parseInt(new Date() / 1000);
+    const now = Math.floor(Date.now() / 1000);
 
 
     db.query('UPDATE sync SET soh=?, charging=?, rapid_charge_port=?, normal_charge_port=?, slow_charge_port=?, aux_battery_voltage=?, dc_battery_voltage=?, dc_battery_current=?, dc_battery_power=?,\
@@ -85,7 +85,7 @@ const getExtended = (akey, callback) => {
  * @param {Function} callback callback function
  */
 const postLocation = (akey, locationObj, callback) => {
-    const now = parseInt(new Date() / 1000);
+    const now = Math.floor(Date.now() / 1000);
 
     db.query('UPDATE sync SET latitude=?, longitude=?, gps_speed=?, accuracy=?, location_timestamp=?, last_location=? WHERE akey=?', [
         locationObj.latitude, locationObj.longitude, locationObj.speed, locationObj.accuracy, locationObj.timestamp, now, akey

--- a/modules/web/account/index.js
+++ b/modules/web/account/index.js
@@ -69,7 +69,7 @@ const login = (mail, password, callback) => {
                 if (!err && valid) {
                     // update last login timestamp
                     db.query('UPDATE login SET last_login=? WHERE id=?', [
-                        parseInt(new Date() / 1000), userObj.id
+                        Math.floor(Date.now() / 1000), userObj.id
                     ], (err, dbRes) => callback(err, ((!err && dbRes) ? userObj.id : null)));
                 } else callback(((err) ? err : srv_errors.INVALID_CREDENTIALS));
             });


### PR DESCRIPTION
Use Math.floor to have timestamp (full second) values.
Use Date.now() to get milliseconds elapsed since the UNIX epoch.

parseInt has string parameter and calculation gives a number also most of the time creation of new Date object is unnecessary.